### PR TITLE
[MM-17418] Change error message wording

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -36,7 +36,7 @@ func (p *Plugin) FileWillBeUploaded(c *plugin.Context, info *model.FileInfo, fil
 			}
 			if scanResult.Status != clamd.RES_OK {
 				p.API.LogWarn("The antivirus service would not allow you to attach this file.", "filename", info.Name, "user", info.CreatorId, "scan_result", scanResult.Raw)
-				return nil, "The antivirus service would not allow you to attach this file."
+				return nil, "The antivirus service did not allow you to attach this file."
 			}
 			continue
 		case <-time.After(time.Duration(config.ScanTimeoutSeconds) * time.Second):

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -35,8 +35,8 @@ func (p *Plugin) FileWillBeUploaded(c *plugin.Context, info *model.FileInfo, fil
 				return info, ""
 			}
 			if scanResult.Status != clamd.RES_OK {
-				p.API.LogWarn("Virus found in file.", "filename", info.Name, "user", info.CreatorId, "scan_result", scanResult.Raw)
-				return nil, "Virus found in file."
+				p.API.LogWarn("The antivirus service would not allow you to attach this file.", "filename", info.Name, "user", info.CreatorId, "scan_result", scanResult.Raw)
+				return nil, "The antivirus service would not allow you to attach this file."
 			}
 			continue
 		case <-time.After(time.Duration(config.ScanTimeoutSeconds) * time.Second):


### PR DESCRIPTION
#### Summary

The ticket was originally made for being specific about certain file extensions when displaying an error for a rejecting file upload. Instead, we've decided to continue returning a generic error message when Clavam gives us an error. However, we have reworded the generic error for better UX.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17418