### PR TITLE
Add more manifest metadata

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,10 @@
     "id": "antivirus",
     "name": "Antivirus",
     "description": "Antivirus plugin for scanning uploaded files.",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-antivirus",
+    "support_url": "https://github.com/mattermost/mattermost-plugin-antivirus/issues",
     "version": "0.1.2",
+    "min_server_version": "5.2.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
Add `homepage_url` and `support_url` to the manifest. `support_url` is not jet used in the webapp, but there is no downside of defining it already.

I've tested the changes locally and can confirm that the link to the `homepage_url` is correctly shown.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21918
