### PR TITLE
mm 25 - Feature Request: support using unix socket to connect to the ClamAV daemon #25

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -17,12 +17,35 @@
     "settings_schema": {
         "header": "Antivirus plugin which uses ClamAV to scan files uploaded to Mattermost. See [documentation here](https://github.com/mattermost/mattermost-plugin-antivirus).",
         "settings": [{
+            "key": "ConnectionType",
+            "display_name": "Connection Type (Unix/Tcp):",
+            "type": "dropdown",
+            "help_text": "Connection Type.",
+            "default": "tcp",
+            "options": [
+                {
+                    "display_name": "Tcp",
+                    "value": "tcp"
+                },
+                {
+                    "display_name": "Unix",
+                    "value": "unix"
+                }
+            ]
+        },{
             "key": "ClamavHostPort",
             "display_name": "ClamAV - Host and Port:",
             "type": "text",
-            "help_text": "The hostname and port to connect to clamd.",
+            "help_text": "The hostname and port to connect to clamd. (required ConnectionType : Tcp)",
             "placeholder": "localhost:3310",
             "default": "localhost:3310"
+        },{
+            "key": "ClamavSocketPath",
+            "display_name": "Socket Path:",
+            "type": "text",
+            "help_text": "Path to socket. (required if connectionType : Unix)",
+            "placeholder": "/tmp/clamd.socket",
+            "default": "/tmp/clamd.socket"
         }, {
             "key": "ScanTimeoutSeconds",
             "display_name": "Scan Timeout (seconds):",
@@ -30,6 +53,7 @@
             "help_text": "How long the virus scan can take before giving up.",
             "placeholder": "10",
             "default": 10
-        }]
+        }
+    ]
     }
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -18,6 +18,8 @@ import (
 type configuration struct {
 	ClamavHostPort     string
 	ScanTimeoutSeconds int
+	ConnectionType     string
+	ClamavSocketPath   string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -22,7 +22,12 @@ type Plugin struct {
 func (p *Plugin) FileWillBeUploaded(c *plugin.Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string) {
 	config := p.getConfiguration()
 
-	av := clamd.NewClamd("tcp://" + config.ClamavHostPort)
+	var av *clamd.Clamd
+	if config.ConnectionType == "tcp" {
+		av = clamd.NewClamd("tcp://" + config.ClamavHostPort)
+	} else {
+		av = clamd.NewClamd(config.ClamavSocketPath)
+	}
 	abortScan := make(chan bool)
 	response, err := av.ScanStream(file, abortScan)
 	if err != nil {


### PR DESCRIPTION
Provided an option in the config settings for the user to select either TCP or UNIX as an option

ticket here
Fixes https://github.com/mattermost/mattermost-plugin-antivirus/issues/25