### PR TITLE
Update ClamAV Docker Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Currently the plugin supports [ClamAV anti-virus software](https://www.clamav.ne
 
    If your Mattermost's MaxFileSize is ≤ 100MB
       ```
-      docker run -d -p 3310:3310 clamav/clamav:latest --restart unless-stopped
+      docker run -d --restart unless-stopped -p 3310:3310 clamav/clamav:latest 
       ```
    If it is > 100MB
       ```
-      docker run -d --mount type=bind,source=/full/path/to/clamav/,target=/etc/clamav -p 3310:3310 clamav/clamav:latest --restart unless-stopped
+      docker run -d --restart unless-stopped --mount type=bind,source=/full/path/to/clamav/,target=/etc/clamav -p 3310:3310 clamav/clamav:latest 
       ```
    `/full/path/to/clamav/clamd.conf`
    ```conf

--- a/README.md
+++ b/README.md
@@ -25,9 +25,29 @@ Currently the plugin supports [ClamAV anti-virus software](https://www.clamav.ne
 
 1. Go to the [releases page of this Github repository](https://github.com/mattermost/mattermost-plugin-antivirus/releases) and download the latest release for your Mattermost server.
 2. In the Mattermost System Console under **System Console > Plugins > Plugin Management** upload the file to install the plugin. To learn more about how to upload a plugin, [see the documentation](https://docs.mattermost.com/administration/plugins.html#plugin-uploads).
-3. Install ClamAV (clamd) for virus scanning. One easy option is to provision a ClamAV container with Docker by running the following command.  Assuming you have already installed Docker, this will download and install the latest version of ClamAV and set up a server with an open port at 3310: and MaxFileSize of 50 MB. Mattermost's MaxFileSize default value is subject to change. To ensure that the correct value is set, verify your value at the following link: [Maximum File Size](https://docs.mattermost.com/administration/config-settings.html#maximum-file-size).  
+
+3. Install ClamAV (clamd) for virus scanning. One easy option is to provision a ClamAV container with Docker by running the following command.  Assuming you have already installed Docker, this will download and install the latest version of ClamAV and set up a server with an open port at 3310. ClamAV by default accepts 100MB files, you can change this in the [`clamd.conf`](https://github.com/Cisco-Talos/clamav/blob/main/etc/clamd.conf.sample). Visit the [ClamAV Documentation](https://docs.clamav.net/manual/Installing/Docker.html) for further configuration. Mattermost's MaxFileSize default value is subject to change. To ensure that the correct value is set, verify your value at the following link: [Maximum File Size](https://docs.mattermost.com/administration/config-settings.html#maximum-file-size).  
+
+   If your Mattermost's MaxFileSize is ≤ 100MB
+      ```
+      docker run -d -p 3310:3310 clamav/clamav:latest --restart unless-stopped
+      ```
+   If it is above
    ```
-   docker run -d -p 3310:3310 clamav/clamav:latest --restart unless-stopped
+   docker run -d --mount type=bind,source=/full/path/to/clamav/,target=/etc/clamav -p 3310:3310 clamav/clamav:latest --restart unless-stopped
+   ```
+   `clamd.conf`
+   ```conf
+   # Files larger than this limit won't be scanned. Affects the input file itself
+   # as well as files contained inside it (when the input file is an archive, a
+   # document or some other kind of container).
+   # Value of 0 disables the limit.
+   # Note: disabling this limit or setting it too high may result in severe damage
+   # to the system.
+   # Technical design limitations prevent ClamAV from scanning files greater than
+   # 2 GB at this time.
+   # Default: 100M
+   MaxFileSize 200M # Match your filezize limit in Mattermost
    ```
 
 4. Once clamd server is running, configure the plugin in Mattermost to make requests to your clamd instance by going to **System Console > Plugins > Antivirus**. Configure **Clamav Host and Port** to point at your clamd instance, and optionally configure a **Scan timeout in seconds** to set how long it takes before the virus scan times out.  

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Currently the plugin supports [ClamAV anti-virus software](https://www.clamav.ne
       ```
       docker run -d -p 3310:3310 clamav/clamav:latest --restart unless-stopped
       ```
-   If it is above
-   ```
-   docker run -d --mount type=bind,source=/full/path/to/clamav/,target=/etc/clamav -p 3310:3310 clamav/clamav:latest --restart unless-stopped
-   ```
-   `clamd.conf`
+   If it is > 100MB
+      ```
+      docker run -d --mount type=bind,source=/full/path/to/clamav/,target=/etc/clamav -p 3310:3310 clamav/clamav:latest --restart unless-stopped
+      ```
+   `/full/path/to/clamav/clamd.conf`
    ```conf
+   ...
    # Files larger than this limit won't be scanned. Affects the input file itself
    # as well as files contained inside it (when the input file is an archive, a
    # document or some other kind of container).
@@ -48,6 +49,7 @@ Currently the plugin supports [ClamAV anti-virus software](https://www.clamav.ne
    # 2 GB at this time.
    # Default: 100M
    MaxFileSize 200M # Match your filezize limit in Mattermost
+   ...
    ```
 
 4. Once clamd server is running, configure the plugin in Mattermost to make requests to your clamd instance by going to **System Console > Plugins > Antivirus**. Configure **Clamav Host and Port** to point at your clamd instance, and optionally configure a **Scan timeout in seconds** to set how long it takes before the virus scan times out.  

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Currently the plugin supports [ClamAV anti-virus software](https://www.clamav.ne
 2. In the Mattermost System Console under **System Console > Plugins > Plugin Management** upload the file to install the plugin. To learn more about how to upload a plugin, [see the documentation](https://docs.mattermost.com/administration/plugins.html#plugin-uploads).
 3. Install ClamAV (clamd) for virus scanning. One easy option is to provision a ClamAV container with Docker by running the following command.  Assuming you have already installed Docker, this will download and install the latest version of ClamAV and set up a server with an open port at 3310: and MaxFileSize of 50 MB. Mattermost's MaxFileSize default value is subject to change. To ensure that the correct value is set, verify your value at the following link: [Maximum File Size](https://docs.mattermost.com/administration/config-settings.html#maximum-file-size).  
    ```
-   docker run -e CLAMD_CONF_MaxFileSize=50M -d -p 3310:3310 mkodockx/docker-clamav
+   docker run -d -p 3310:3310 clamav/clamav:latest --restart unless-stopped
    ```
 
 4. Once clamd server is running, configure the plugin in Mattermost to make requests to your clamd instance by going to **System Console > Plugins > Antivirus**. Configure **Clamav Host and Port** to point at your clamd instance, and optionally configure a **Scan timeout in seconds** to set how long it takes before the virus scan times out.  

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Currently the plugin supports [ClamAV anti-virus software](https://www.clamav.ne
 
 ## Testing
 
-To test your configuration is correct, create an [EICAR test file](https://2016.eicar.org/86-0-Intended-use.html) (copy the text from that webpage into a text file editor and save it) and upload it. The file should be rejected as below:
+To test your configuration is correct, download an [EICAR test file](https://www.eicar.org/download-anti-malware-testfile/)and upload it. The file should be rejected as below:
 
 ![Screenshot of Anti-virus in action](/2019-07-26_13-56-13.png)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Currently the plugin supports [ClamAV anti-virus software](https://www.clamav.ne
 
 ## Testing
 
-To test your configuration is correct, download an [EICAR test file](https://www.eicar.org/download-anti-malware-testfile/)and upload it. The file should be rejected as below:
+To test your configuration is correct, download an [EICAR test file](https://www.eicar.org/download-anti-malware-testfile/) and upload it. The file should be rejected as below:
 
 ![Screenshot of Anti-virus in action](/2019-07-26_13-56-13.png)
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Primarily to address the discontinuation of the previous listed container in the command 


[mko-x/docker-clamav](https://github.com/mko-x/docker-clamav) :
" The development of this image will be discontinued. Since [0.104](https://github.com/Cisco-Talos/clamav/blob/main/NEWS.md#01040) Cisco provides official docker images for clamav. This image here will be on hold and supported as long as possible.

At the moment we are faced with unexpected disconnects during database updates. This might be due to changes in the database download handling from the clamav servers. "

Updated the command and README to the official ClamAV Docker image and further configuration changes that might be required for Mattermost User with MaxFileSizes above 100MB


